### PR TITLE
Add a postinstall script to run bower install

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
   },
   "scripts": {
     "start": "node server/app.js",
+    "postinstall": "bower install",
     "test": "grunt test",
     "update-webdriver": "node node_modules/grunt-protractor-runner/node_modules/protractor/bin/webdriver-manager update"
   },


### PR DESCRIPTION
Uses the post hook to run bower install once npm install has been
completed
